### PR TITLE
Add simple scrapers for Copa, ConnectMiles and Skyscanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ módulo principal `research_planner.py` e pelos testes unitários em `tests/`.
 .
 ├── README.md
 ├── research_planner.py
+├── scrapers.py
 └── tests
-    └── test_research_planner.py
+    ├── test_research_planner.py
+    └── test_scrapers.py
 ```
 
 ## Execução dos testes
@@ -28,3 +30,9 @@ Requisitos: [pytest](https://pytest.org/).
 pip install pytest
 pytest
 ```
+
+## Scrapers de companhias aéreas
+
+O módulo `scrapers.py` inclui funções que demonstram como coletar preços de voo
+na Copa Airlines e Skyscanner, além de consultar o saldo do programa ConnectMiles.
+Antes de realizar scraping, verifique os termos de uso de cada serviço.

--- a/scrapers.py
+++ b/scrapers.py
@@ -1,0 +1,68 @@
+"""Real web scrapers for Copa Airlines, ConnectMiles and Skyscanner.
+
+The implementations rely only on the Python standard library. They are minimal
+examples intended for educational use; always verify the terms of service of
+any website before scraping.
+"""
+from __future__ import annotations
+
+from typing import List
+import re
+import urllib.parse
+import urllib.request
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/114.0 Safari/537.36"
+    )
+}
+
+
+def _http_get(url: str) -> str:
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return resp.read().decode("utf-8")
+
+
+def _http_post(url: str, data: dict) -> str:
+    encoded = urllib.parse.urlencode(data).encode()
+    req = urllib.request.Request(url, data=encoded, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return resp.read().decode("utf-8")
+
+
+def scrape_copa_airlines(origin: str, destination: str, depart_date: str) -> List[str]:
+    """Return flight prices from Copa Airlines search results."""
+
+    url = (
+        "https://www.copaair.com/en-us/flights/" f"{origin}-{destination}?departure={depart_date}"
+    )
+    html = _http_get(url)
+    return re.findall(r'class="price">([^<]+)<', html)
+
+
+def scrape_connect_miles(username: str, password: str) -> str:
+    """Return mileage balance from ConnectMiles."""
+
+    login_html = _http_get("https://www.connectmiles.com/login")
+    token_match = re.search(r'name="csrf_token" value="([^"]+)"', login_html)
+    token = token_match.group(1) if token_match else ""
+    _http_post(
+        "https://www.connectmiles.com/login",
+        {"username": username, "password": password, "csrf_token": token},
+    )
+    account_html = _http_get("https://www.connectmiles.com/account")
+    balance_match = re.search(r'id="available-miles">([^<]+)<', account_html)
+    return balance_match.group(1).strip() if balance_match else ""
+
+
+def scrape_skyscanner(origin: str, destination: str, depart_date: str) -> List[str]:
+    """Return flight prices from Skyscanner search results."""
+
+    url = (
+        "https://www.skyscanner.com.br/transport/flights/" f"{origin}/{destination}/{depart_date}/"
+    )
+    html = _http_get(url)
+    return re.findall(r'class="price">([^<]+)<', html)
+

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -1,0 +1,39 @@
+import scrapers
+
+
+def test_scrape_copa_airlines(monkeypatch):
+    html = '<div class="price">$100</div><div class="price">$200</div>'
+    monkeypatch.setattr(scrapers, "_http_get", lambda url: html)
+    prices = scrapers.scrape_copa_airlines("AAA", "BBB", "2024-01-01")
+    assert prices == ["$100", "$200"]
+
+
+def test_scrape_skyscanner(monkeypatch):
+    html = '<span class="price">R$300</span>'
+    monkeypatch.setattr(scrapers, "_http_get", lambda url: html)
+    prices = scrapers.scrape_skyscanner("AAA", "BBB", "2024-01-01")
+    assert prices == ["R$300"]
+
+
+def test_scrape_connect_miles(monkeypatch):
+    login_html = '<input name="csrf_token" value="token123">'
+    account_html = '<div id="available-miles">12345</div>'
+
+    def fake_get(url: str) -> str:
+        if "login" in url:
+            return login_html
+        return account_html
+
+    posted = {}
+
+    def fake_post(url: str, data: dict) -> str:
+        posted.update(data)
+        return ""
+
+    monkeypatch.setattr(scrapers, "_http_get", fake_get)
+    monkeypatch.setattr(scrapers, "_http_post", fake_post)
+    balance = scrapers.scrape_connect_miles("user", "pass")
+    assert balance == "12345"
+    assert posted["username"] == "user"
+    assert posted["password"] == "pass"
+    assert posted["csrf_token"] == "token123"


### PR DESCRIPTION
## Summary
- add scraper functions for Copa Airlines, ConnectMiles and Skyscanner using urllib
- document scraper module in README
- test scraper logic with monkeypatched HTTP helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e92a3183c83298f9f615c4fc0c79b