### PR TITLE
Add Firecrawl setup and usage routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Firecrawl — web search / scraping / interaction / monitoring
+# Get a key: https://www.firecrawl.dev/signin?view=signup (dashboard → API keys)
+FIRECRAWL_API_KEY=fc-your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Secrets / local config
+.env
+.env.local
+
+# Firecrawl local cache
+.firecrawl/
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.venv/
+venv/
+
+# Node (dashboard tooling)
+node_modules/
+
+# OS / editor
+.DS_Store
+.vscode/
+.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# celest.ia — agent notes
+
+Research planner prototype (`research_planner.py`) with flight-price scrapers
+(`scrapers.py`: Copa Airlines, Skyscanner, ConnectMiles) and a dashboard under
+`celestia_dashboard/`. Tests run with `pytest`.
+
+## Web data: use Firecrawl
+
+Firecrawl is the web-data layer for this repo. Routing:
+
+- **Need web data during a session** (search, scrape a URL, drive a page) →
+  Firecrawl CLI / `firecrawl` skills (`firecrawl-search`, `firecrawl-scrape`,
+  `firecrawl-interact`).
+- **Wiring web data into this codebase** (replacing the `urllib` + regex
+  scrapers) → `firecrawl-build` skills; endpoint mapping lives in
+  [FIRECRAWL.md](FIRECRAWL.md).
+- **Recurring checks** ("track this fare", "alert when it changes") →
+  `/monitor` via `firecrawl monitor create`, not repeated one-off scrapes.
+- **Finished deliverables** (research brief, competitive fare digest) →
+  `firecrawl-workflows` skills.
+
+Setup, credentials, verification, and the remote-session proxy fix are in
+[FIRECRAWL.md](FIRECRAWL.md). If skills/CLI are missing in a fresh session:
+`npx -y firecrawl-cli@latest init --all -y -k "$FIRECRAWL_API_KEY"`.
+
+`FIRECRAWL_API_KEY` comes from `.env` (copy `.env.example`); never commit a
+real key.

--- a/FIRECRAWL.md
+++ b/FIRECRAWL.md
@@ -1,0 +1,100 @@
+# Firecrawl setup & routing — celest.ia
+
+Firecrawl is set up as the web-data layer for this project: search, clean
+scraping, browser interaction (logins, forms), document parsing, research
+index, and page-change monitoring.
+
+## Install (one command, three skill segments)
+
+```bash
+npx -y firecrawl-cli@latest init --all --browser
+```
+
+Running headless / in an agent session with a key already available:
+
+```bash
+npx -y firecrawl-cli@latest init --all -y -k "$FIRECRAWL_API_KEY"
+```
+
+This installs the `firecrawl` CLI globally, authenticates, and installs three
+skill segments for AI coding agents:
+
+| Segment         | Question it answers                                   | Use in this repo                            |
+| --------------- | ----------------------------------------------------- | ------------------------------------------- |
+| CLI skills      | "Which Firecrawl command should I run right now?"     | Ad-hoc research, debugging a scraper target |
+| Build skills    | "How do I add a Firecrawl API call to this codebase?" | Replacing/backing `scrapers.py` (see below) |
+| Workflow skills | "What finished deliverable should I produce?"         | Fare intel digests, research briefs         |
+
+## Credentials
+
+```bash
+# .env (gitignored — never commit a real key)
+FIRECRAWL_API_KEY=fc-your-key-here
+```
+
+Copy `.env.example` to `.env` and fill in your key. Get a key at
+<https://www.firecrawl.dev/signin?view=signup> (dashboard → API keys), or let
+the CLI's browser auth store one for you.
+
+## Verify
+
+```bash
+mkdir -p .firecrawl
+firecrawl --status                                          # expect: Authenticated
+firecrawl scrape "https://firecrawl.dev" -o .firecrawl/install-check.md
+```
+
+`.firecrawl/` is a local cache and is gitignored.
+
+## Routing for this repo
+
+This project's primary fit is **app integration (Path B)**: `scrapers.py`
+currently drives Copa Airlines, Skyscanner, and ConnectMiles with raw
+`urllib` + regex, which breaks on JavaScript-rendered pages and can't handle
+logins. Map each function to a Firecrawl endpoint:
+
+| Current code                             | Problem                                  | Firecrawl endpoint                                                        |
+| ---------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
+| `scrape_copa_airlines()`                 | JS-rendered results page, brittle regex  | `/scrape` (rendered markdown/JSON) after `/search` or a known results URL |
+| `scrape_skyscanner()`                    | Same, plus heavy bot protection          | `/scrape`; escalate to `/interact` when the page needs the search form    |
+| `scrape_connect_miles()`                 | CSRF login flow, session state           | `/interact` (browser actions: fill login, navigate, extract balance)      |
+| Recurring fare checks (research planner) | Re-scraping the same URLs on a schedule  | `/monitor` — diffs checks, AI judge filters noise, webhook/email/Slack    |
+| Literature / prior-art lookups           | Manual searching                         | `/search` + research index (`/search/research/papers`, `search-github`)   |
+
+Python SDK for the integration:
+
+```bash
+pip install firecrawl-py
+```
+
+```python
+import os
+from firecrawl import Firecrawl
+
+fc = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
+doc = fc.scrape("https://www.copaair.com/...", formats=["markdown"])
+```
+
+When implementing, hand off to the `firecrawl-build` skill (endpoint routing,
+SDK call sites, smoke test). For one-off data pulls during a session, use the
+CLI directly (`firecrawl search`, `firecrawl scrape`, `firecrawl interact`).
+For finished deliverables (e.g. a fare-comparison brief), start from the
+`firecrawl-workflows` skill.
+
+## Claude Code on the web — proxy note
+
+Remote sessions route HTTPS through an agent proxy. If `firecrawl` commands
+fail with `405 Method Not Allowed`, the bundled axios (< 1.16.1) is sending
+non-CONNECT proxy requests. Fix without touching TLS settings:
+
+```bash
+cd "$(npm root -g)/firecrawl-cli" && npm install axios@latest --no-save
+cd "$(npm root -g)/firecrawl-cli/node_modules/firecrawl" && npm install axios@latest --no-save
+```
+
+## Rerun inputs
+
+- Install: `npx -y firecrawl-cli@latest init --all -y -k "$FIRECRAWL_API_KEY"`
+- Verify: `firecrawl --status` + scrape check above
+- Key: `FIRECRAWL_API_KEY` in `.env` (local) or session env
+- Docs: <https://docs.firecrawl.dev> · Skills: <https://github.com/firecrawl/skills>

--- a/README.md
+++ b/README.md
@@ -36,3 +36,11 @@ pytest
 O módulo `scrapers.py` inclui funções que demonstram como coletar preços de voo
 na Copa Airlines e Skyscanner, além de consultar o saldo do programa ConnectMiles.
 Antes de realizar scraping, verifique os termos de uso de cada serviço.
+
+## Dados da web via Firecrawl
+
+O projeto usa o [Firecrawl](https://docs.firecrawl.dev) como camada de dados
+da web (busca, scraping renderizado, interação com páginas com login e
+monitoramento de mudanças). Instalação, credenciais (`.env.example`) e o
+roteamento de cada scraper para o endpoint correto estão em
+[FIRECRAWL.md](FIRECRAWL.md).


### PR DESCRIPTION
## Summary

Sets up [Firecrawl](https://docs.firecrawl.dev) as the project's web-data layer and routes each part of the codebase to the right usage path. The CLI + all three skill segments (CLI / build / workflow) were installed and verified live in-session (`firecrawl --status` authenticated; test scrape of firecrawl.dev succeeded).

## Changes

- **FIRECRAWL.md** — setup and routing guide:
  - one-command install (`npx -y firecrawl-cli@latest init --all`), credentials, and verification steps
  - endpoint routing for `scrapers.py`: Copa/Skyscanner → `/search` + `/scrape`, ConnectMiles login → `/interact`, recurring fare checks → `/monitor`, literature lookups → research index
  - Python SDK (`firecrawl-py`) call sketch for the integration
  - remote-session proxy note: `405 Method Not Allowed` is the bundled axios < 1.16.1 sending non-CONNECT proxy requests; fix is upgrading axios inside the global CLI (commands included)
- **CLAUDE.md** — agent-facing routing (CLI vs build vs workflows) so future Claude sessions pick the right path immediately
- **.env.example** — `FIRECRAWL_API_KEY` placeholder; real keys stay local
- **.gitignore** (new) — `.env`, `.firecrawl/` cache, Python/Node artifacts
- **README.md** — links the guide from the scrapers section (PT-BR, matching the README)

No application code changed; the actual scraper migration to Firecrawl endpoints is mapped in FIRECRAWL.md as follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNsY8XGydaT94Xh3cWQt91

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNsY8XGydaT94Xh3cWQt91)_